### PR TITLE
used fixed babel-plugin-htmlbars-inline-precompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ precompileTemplate(`
 From a javascript point of view, everything is correct and both examples are equivalent. But the second example will fail with the following error:
 
 [Scope objects for `precompileTemplate` may only contain direct references to in-scope values](https://github.com/candunaj/template-precompile-scope/actions/runs/4478830537/jobs/7872086147#step:7:62)
+
+The scope was fixed in [babel-plugin-htmlbars-inline-precompile](https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/486) and added as override to package json. Now tests are passing.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@types/eslint": "^7.0.0"
+      "@types/eslint": "^7.0.0",
+      "babel-plugin-htmlbars-inline-precompile": "github:candunaj/babel-plugin-htmlbars-inline-precompile#precompile-template-scope-renamed-import-build"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   '@types/eslint': ^7.0.0
+  babel-plugin-htmlbars-inline-precompile: github:candunaj/babel-plugin-htmlbars-inline-precompile#precompile-template-scope-renamed-import-build
 
 importers:
 
@@ -2770,17 +2771,6 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /babel-plugin-htmlbars-inline-precompile/5.3.1:
-    resolution: {integrity: sha512-QWjjFgSKtSRIcsBhJmEwS2laIdrA6na8HAlc/pEAhjHgQsah/gMiBFRZvbQTy//hWxR4BMwV7/Mya7q5H8uHeA==}
-    engines: {node: 10.* || >= 12.*}
-    dependencies:
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      line-column: 1.0.2
-      magic-string: 0.25.9
-      parse-static-imports: 1.1.0
-      string.prototype.matchall: 4.0.8
-    dev: true
-
   /babel-plugin-module-resolver/3.2.0:
     resolution: {integrity: sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==}
     engines: {node: '>= 6.0.0'}
@@ -4567,7 +4557,7 @@ packages:
       '@embroider/shared-internals': 2.0.0
       babel-loader: 8.3.0_h5x7dh6zbbyopr7jvxivhylqpa
       babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-htmlbars-inline-precompile: github.com/candunaj/babel-plugin-htmlbars-inline-precompile/393443d655c04e1615011ea043c1602c2d782a58
       babel-plugin-syntax-dynamic-import: 6.18.0
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
@@ -4672,7 +4662,7 @@ packages:
     engines: {node: 10.* || >= 12.*}
     dependencies:
       '@ember/edition-utils': 1.2.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-htmlbars-inline-precompile: github.com/candunaj/babel-plugin-htmlbars-inline-precompile/393443d655c04e1615011ea043c1602c2d782a58
       broccoli-debug: 0.6.5
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
@@ -4697,7 +4687,7 @@ packages:
     dependencies:
       '@ember/edition-utils': 1.2.0
       babel-plugin-ember-template-compilation: 2.0.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-htmlbars-inline-precompile: github.com/candunaj/babel-plugin-htmlbars-inline-precompile/393443d655c04e1615011ea043c1602c2d782a58
       broccoli-debug: 0.6.5
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
@@ -11346,4 +11336,19 @@ packages:
   /yocto-queue/1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  github.com/candunaj/babel-plugin-htmlbars-inline-precompile/393443d655c04e1615011ea043c1602c2d782a58:
+    resolution: {tarball: https://codeload.github.com/candunaj/babel-plugin-htmlbars-inline-precompile/tar.gz/393443d655c04e1615011ea043c1602c2d782a58}
+    name: babel-plugin-htmlbars-inline-precompile
+    version: 5.3.1
+    engines: {node: 10.* || >= 12.*}
+    prepare: true
+    requiresBuild: true
+    dependencies:
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      line-column: 1.0.2
+      magic-string: 0.25.9
+      parse-static-imports: 1.1.0
+      string.prototype.matchall: 4.0.8
     dev: true


### PR DESCRIPTION
This PR demonstrates that [PR](https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/486) for babel-plugin-htmlbars-inline-precompile fixed the bug with renamed scope.
