### PR TITLE
Fixed babel plugin ember template compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@types/eslint": "^7.0.0"
+      "@types/eslint": "^7.0.0",
+      "ember-auto-import": "github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "pnpm": {
     "overrides": {
       "@types/eslint": "^7.0.0",
-      "ember-auto-import": "github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build"
+      "ember-auto-import": "github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build",
+      "babel-plugin-ember-template-compilation": "github:candunaj/babel-plugin-ember-template-compilation#scope-fix-build"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   '@types/eslint': ^7.0.0
+  ember-auto-import: github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build
 
 importers:
 
@@ -67,7 +68,7 @@ importers:
       babel-eslint: ^10.1.0
       broccoli-asset-rev: ^3.0.0
       concurrently: ^7.6.0
-      ember-auto-import: ^2.5.0
+      ember-auto-import: github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build
       ember-cli: ~4.10.0
       ember-cli-app-version: ^5.0.0
       ember-cli-babel: ^7.26.11
@@ -109,7 +110,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
-      ember-auto-import: 2.6.1_webpack@5.76.2
+      ember-auto-import: github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d_webpack@5.76.2
       ember-cli: 4.10.0
       ember-cli-app-version: 5.0.0
       ember-cli-babel: 7.26.11
@@ -4555,45 +4556,6 @@ packages:
     resolution: {integrity: sha512-laZ1odk+TRen6q0GeyQx/JEkpD3iSZT7ewopCpKqg9bTjP1l8XRfU3Bg20CFjNPZkp5+NDBl3iqd4o/kPO+Vew==}
     dev: true
 
-  /ember-auto-import/2.6.1_webpack@5.76.2:
-    resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.3
-      '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.3
-      '@babel/preset-env': 7.20.2_@babel+core@7.21.3
-      '@embroider/macros': 1.10.0
-      '@embroider/shared-internals': 2.0.0
-      babel-loader: 8.3.0_h5x7dh6zbbyopr7jvxivhylqpa
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      babel-plugin-syntax-dynamic-import: 6.18.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      css-loader: 5.2.7_webpack@5.76.2
-      debug: 4.3.4
-      fs-extra: 10.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.7
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.7.5_webpack@5.76.2
-      parse5: 6.0.1
-      resolve: 1.22.1
-      resolve-package-path: 4.0.3
-      semver: 7.3.8
-      style-loader: 2.0.0_webpack@5.76.2
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-      - webpack
-    dev: true
-
   /ember-cli-app-version/5.0.0:
     resolution: {integrity: sha512-afhx/CXDOMNXzoe4NDPy5WUfxWmYYHUzMCiTyvPBxCDBXYcMrtxNWxvgaSaeqcoHVEmqzeyBj8V82tzmT1dcyw==}
     engines: {node: 10.* || >= 12}
@@ -5145,7 +5107,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
-      ember-auto-import: 2.6.1_webpack@5.76.2
+      ember-auto-import: github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d_webpack@5.76.2
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
       ember-source: 4.10.0_j6mhgbor4xqonp65vkpdi5nj6q
@@ -5218,7 +5180,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.1_webpack@5.76.2
+      ember-auto-import: github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d_webpack@5.76.2
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -11346,4 +11308,46 @@ packages:
   /yocto-queue/1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d_webpack@5.76.2:
+    resolution: {tarball: https://codeload.github.com/candunaj/ember-auto-import/tar.gz/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d}
+    id: github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d
+    name: ember-auto-import
+    version: 2.6.1
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.21.3
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.3
+      '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.3
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.3
+      '@embroider/macros': 1.10.0
+      '@embroider/shared-internals': 2.0.0
+      babel-loader: 8.3.0_h5x7dh6zbbyopr7jvxivhylqpa
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7_webpack@5.76.2
+      debug: 4.3.4
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.7.5_webpack@5.76.2
+      parse5: 6.0.1
+      resolve: 1.22.1
+      resolve-package-path: 4.0.3
+      semver: 7.3.8
+      style-loader: 2.0.0_webpack@5.76.2
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - webpack
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 overrides:
   '@types/eslint': ^7.0.0
   ember-auto-import: github:candunaj/ember-auto-import#added-babel-plugin-ember-template-compilation-build
+  babel-plugin-ember-template-compilation: github:candunaj/babel-plugin-ember-template-compilation#scope-fix-build
 
 importers:
 
@@ -1597,7 +1598,7 @@ packages:
       '@embroider/shared-internals': 2.0.0
       assert-never: 1.2.1
       babel-import-util: 1.3.0
-      babel-plugin-ember-template-compilation: 2.0.0
+      babel-plugin-ember-template-compilation: github.com/candunaj/babel-plugin-ember-template-compilation/696195e0ee672e805d2f8b7f6496a0d8b579edd3
       broccoli-node-api: 1.7.0
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
@@ -2754,13 +2755,6 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
       ember-rfc176-data: 0.3.18
-    dev: true
-
-  /babel-plugin-ember-template-compilation/2.0.0:
-    resolution: {integrity: sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==}
-    engines: {node: '>= 12.*'}
-    dependencies:
-      babel-import-util: 1.3.0
     dev: true
 
   /babel-plugin-filter-imports/4.0.0:
@@ -4658,7 +4652,7 @@ packages:
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       '@ember/edition-utils': 1.2.0
-      babel-plugin-ember-template-compilation: 2.0.0
+      babel-plugin-ember-template-compilation: github.com/candunaj/babel-plugin-ember-template-compilation/696195e0ee672e805d2f8b7f6496a0d8b579edd3
       babel-plugin-htmlbars-inline-precompile: 5.3.1
       broccoli-debug: 0.6.5
       broccoli-persistent-filter: 3.1.3
@@ -11308,6 +11302,15 @@ packages:
   /yocto-queue/1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  github.com/candunaj/babel-plugin-ember-template-compilation/696195e0ee672e805d2f8b7f6496a0d8b579edd3:
+    resolution: {tarball: https://codeload.github.com/candunaj/babel-plugin-ember-template-compilation/tar.gz/696195e0ee672e805d2f8b7f6496a0d8b579edd3}
+    name: babel-plugin-ember-template-compilation
+    version: 2.0.0
+    engines: {node: '>= 12.*'}
+    dependencies:
+      babel-import-util: 1.3.0
     dev: true
 
   github.com/candunaj/ember-auto-import/5e53dd46cd2bbb67766d8a692c65d5befa72bd3d_webpack@5.76.2:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -66,7 +66,7 @@
     "webpack": "^5.75.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This PR demonstrates that fixed babel-plugin-ember-tempalte-compilation [PR](https://github.com/emberjs/babel-plugin-ember-template-compilation/pull/17) fixed the problem with renamed scope.